### PR TITLE
Add option for functional tests coverage in CI

### DIFF
--- a/.github/workflows/reusable-CI-for-PHP.yml
+++ b/.github/workflows/reusable-CI-for-PHP.yml
@@ -7,6 +7,11 @@ on:
         description: Path to the supported versions file
         required: true
         type: string
+      with-functional-tests-coverage:
+        description: Whether to include functional tests coverage
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -109,7 +114,7 @@ jobs:
           path: build/coverage-groups
 
       - name: Create "functional tests" reports group
-        if: ${{ env.COVERAGE_TYPE == 'xdebug' }}
+        if: ${{ env.COVERAGE_TYPE == 'xdebug' && inputs.with-functional-tests-coverage == true }}
         uses: yoanm/temp-reports-group-workspace/create-group@v0
         with:
           name: functional-tests


### PR DESCRIPTION
## 📑 Description
Add option to avoid managing functional tests coverage in CI

## ✅ Checks
<!-- 
WARNING: Be sure the following task are completed before moving the PR from "Draft" to "Ready for review"
-->
Before moving to "Ready for review" mode, the following must be completed:
- [ ] `Required` CI checks are all green

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
